### PR TITLE
Fix euler logging comment

### DIFF
--- a/Firmware/_9DoF_Razor_M0_Firmware/config.h
+++ b/Firmware/_9DoF_Razor_M0_Firmware/config.h
@@ -64,7 +64,7 @@
 #define ENABLE_COMPASS    'm' // Enable/disable magnetometer log (mx, my, mz)
 #define ENABLE_CALC       'c' // Enable/disable calculated values
 #define ENABLE_QUAT       'q' // Enable/disable quaternion logging (qw, qx, qy, qz)
-#define ENABLE_EULER      'e' // Enable/disable estimated euler angles (roll, pitch, yaw)
+#define ENABLE_EULER      'e' // Enable/disable estimated euler angles (pitch, roll, yaw)
 #define ENABLE_HEADING    'h' // Enable/disable estimated heading logging
 #define SET_LOG_RATE      'r' // Adjust logging rate from 1-200 Hz (in 10 Hz increments)
 #define SET_ACCEL_FSR     'A' // Set accelerometer FSR (2, 4, 8, 16g)


### PR DESCRIPTION
The angles are actually printed in Pitch, Roll, Yaw order.

https://github.com/sparkfun/9DOF_Razor_IMU/blob/51dbea98591c547e73c2511f2339e35e4bd7ad48/Firmware/_9DoF_Razor_M0_Firmware/_9DoF_Razor_M0_Firmware.ino#L240